### PR TITLE
v. 0.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## 0.5.0
+ * Added `languages` argument to PiiProcessor, to restrict the pre-collection
+   of tasks
+ * Ensure a task is not built twice in the same PiiTaskCollection, if it's for
+   the same language
+ * fixed task_info api call & script
+
 ## 0.4.0
  * PiiCollectionBuilder modified, adding methods add_detector_fields() &
    add_collection()

--- a/doc/task-collection.md
+++ b/doc/task-collection.md
@@ -17,7 +17,7 @@ A pii-extract plugin is a Python package that must have:
   * the entry point must be a class with:
      - a constructor (with optional arguments, see below)
      - a `get_tasks()` method delivering an iterable of task descriptors, with
-       an optional "lang" argument to restrict to a specific language
+       an optional "lang" argument to restrict tasks to one specific language
      - optional attributes `source`, `version` and `description`
 
 Plugin instantiation can be customized by a
@@ -28,10 +28,11 @@ by plugin entry point. Each plugin configuration can contain:
  * `options`: a dict of keyword arguments to pass to the plugin
    constructor. Those are specific for each plugin, and they are passed "as is".
  
- 
 A plugin constructor will have as arguments:
  * `config`: a PIISA configuration object, from which it can take its own
    section, if present
+ * `languages`: a list of languages to act as a pre-filter, restricting the
+   tasks provided by the plugin to those languages
  * `debug`: a boolean to activate debug output
  * `**options`: additional arguments, as defined in the extract config
  
@@ -39,6 +40,7 @@ One example of a plugin is [pii-extract-plg-regex].
 
 Installed plugins are automatically discovered by `pii-extract-base`, so if
 the task is inside a plugin, no further action is needed. 
+
 
 ## JSON
 

--- a/doc/task-descriptor.md
+++ b/doc/task-descriptor.md
@@ -78,7 +78,7 @@ their values from elsewhere:
 
 ### PII Entity
 
-The PII field in the full task descriptor defines the [PII Entities] that will
+The `pii` field in the full task descriptor defines the [PII Entities] that will
 be detected by the task. Its main form is as a dictionary with the folllowing
 fields:
  * `type`: the PII Entity identifier for the task. It can be

--- a/src/pii_extract/__init__.py
+++ b/src/pii_extract/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.4.0"
+VERSION = "0.5.0"

--- a/src/pii_extract/api/file.py
+++ b/src/pii_extract/api/file.py
@@ -17,22 +17,23 @@ from ..defs import FMT_CONFIG_PLUGIN, FMT_CONFIG_TASKS
 from . import PiiProcessor
 
 
-def print_tasks(lang: str, proc: PiiProcessor, out: TextIO):
+def print_tasks(langlist: List[str], proc: PiiProcessor, out: TextIO):
     """
     Print out the list of built tasks
     """
     tw = TextWrapper(initial_indent="     ", subsequent_indent="     ", width=78)
-    print(f". Built tasks [language={lang}]", file=out)
+    print(f". Built tasks [language={','.join(langlist)}]", file=out)
     for (pii, subtype), tasklist in proc.task_info().items():
         print(f"\n {pii.name}   {subtype if subtype else ''}", file=out)
-        for n, (country, name, doc) in enumerate(tasklist):
+        for n, (lang, country, name, doc) in enumerate(tasklist):
             if n:
-                print()
-            print(f"   Country: {country}")
-            print(f"   Name: {name}")
+                print(file=out)
+            print(f"   Language: {lang}", file=out)
+            print(f"   Country: {country}", file=out)
+            print(f"   Name: {name}", file=out)
             if doc:
                 for ln in doc.splitlines():
-                    print(tw.fill(ln))
+                    print(tw.fill(ln), file=out)
 
 
 def print_stats(stats: Dict[str, Dict], out: TextIO):

--- a/src/pii_extract/app/task_info.py
+++ b/src/pii_extract/app/task_info.py
@@ -52,9 +52,12 @@ def task_info(args: argparse.Namespace, out: TextIO):
     """
     config = load_config(args.config) if args.config else None
     proc = PiiProcessor(config=config, skip_plugins=args.skip_plugins,
-                        debug=args.debug)
-    proc.build_tasks(args.lang, args.country, pii=args.tasks,
-                     add_any=not args.strict)
+                        languages=args.lang, debug=args.debug)
+
+    for lang in args.lang or [None]:
+        proc.build_tasks(lang, args.country, pii=args.tasks,
+                         add_any=not args.strict)
+
     print_tasks(args.lang, proc, out)
 
 
@@ -71,7 +74,7 @@ def parse_args(args: List[str]) -> argparse.Namespace:
 
     opt_com2 = argparse.ArgumentParser(add_help=False)
     c1 = opt_com2.add_argument_group('Task selection options')
-    c1.add_argument("--lang", help="language to select")
+    c1.add_argument("--lang", nargs="+", help="language(s) to select")
     c1.add_argument("--country", nargs="+", help="countries to select")
     c1.add_argument("--strict", action="store_true",
                     help="Include only tasks that comply strictly with selection")

--- a/src/pii_extract/build/build.py
+++ b/src/pii_extract/build/build.py
@@ -19,6 +19,7 @@ def is_pii_class(obj: Any) -> bool:
 def build_task(taskd: Dict) -> BasePiiTask:
     """
     Build a task object from its task definition
+      :param taskd: a task definition (i.e. a *parsed* task descriptor)
     """
     # Prepare standard arguments
     try:

--- a/src/pii_extract/gather/collection/get.py
+++ b/src/pii_extract/gather/collection/get.py
@@ -2,7 +2,7 @@
 Gather and return the collection of tasks from all available sources
 """
 
-from typing import Dict
+from typing import Dict, Iterable, Union
 
 from pii_data.helper.logger import PiiLogger
 
@@ -14,6 +14,7 @@ from .task_collection import PiiTaskCollection
 LOGGER = None
 
 def get_task_collection(config: Dict = None, load_plugins: bool = True,
+                        languages: Union[str, Iterable[str]] = None,
                         debug: bool = False) -> PiiTaskCollection:
     """
     Create a task collection object & collect all available tasks
@@ -27,18 +28,20 @@ def get_task_collection(config: Dict = None, load_plugins: bool = True,
     LOGGER("get_task_collection")
 
     piic = PiiTaskCollection(debug=debug)
+    if languages:
+        languages = [languages] if isinstance(languages, str) else list(languages)
 
     # Add task descriptors from installed plugins
     if load_plugins:
         LOGGER("load plugin tasks")
-        c = PluginTaskCollector(config=config, debug=debug)
+        c = PluginTaskCollector(config=config, languages=languages, debug=debug)
         piic.add_collector(c)
 
     # Add task descriptors from JSON configs
     task_cfg = config.get(FMT_CONFIG_TASKS) if config else None
     if task_cfg:
         LOGGER("load JSON tasks")
-        c = JsonTaskCollector(debug=debug)
+        c = JsonTaskCollector(languages=languages, debug=debug)
         c.add_tasks(task_cfg)
         piic.add_collector(c)
 

--- a/src/pii_extract/gather/collection/sources/base.py
+++ b/src/pii_extract/gather/collection/sources/base.py
@@ -26,14 +26,14 @@ class BaseTaskCollector:
     implementations.
     """
 
-    def __init__(self, debug: bool = False):
+    def __init__(self, languages: Iterable[str] = None, debug: bool = False):
         """
-          :param pkg: basename for the package
-          :param basedir: base directory where the task implementations are
+          :param languages: restrict collection to some languages
           :param debug: print out debug information
         """
         self._debug = debug
         self._country = None
+        self._lang = set(languages) if languages else None
         self._log = PiiLogger(__name__, debug)
 
 

--- a/src/pii_extract/gather/collection/sources/folder.py
+++ b/src/pii_extract/gather/collection/sources/folder.py
@@ -64,22 +64,22 @@ class FolderTaskCollector(BaseTaskCollector):
 
     def __init__(self, pkg: str, basedir: Path, source: str,
                  version: str = None, pii_filter: List[PiiEnum] = None,
-                 debug: bool = False):
+                 languages: Iterable[str] = None, debug: bool = False):
         """
           :param pkg: basename for the package
           :param basedir: base directory where the task implementations are
           :param source: source for the tasks (vendor/organization/package)
           :param version: version for the tasks
           :param pii_filter: collect only tasks for these PII types
+          :param languages: currently unused
           :param debug: print out debug information
         """
-        super().__init__(debug=debug)
-        self.basedir = Path(basedir)
-        self._debug = debug
+        super().__init__(languages=languages, debug=debug)
         self._pkg = pkg
         self._defaults = {'source': source or pkg}
         if version:
             self._defaults['version'] = version
+        self.basedir = Path(basedir)
         self._log(".. Folder task collector (%s, version=%s): init",
                   self.__class__.__name__, version)
 
@@ -155,7 +155,11 @@ class FolderTaskCollector(BaseTaskCollector):
         """
         Return all languages defined in the package
         """
-        return mod_subdir(self.basedir)
+        all_lang = mod_subdir(self.basedir)
+        if not self._lang:
+            return all_lang
+        else:
+            return [ln for ln in all_lang if ln in self._lang or ln == LANG_ANY]
 
 
     def country_list(self, lang: str = None) -> List[str]:
@@ -178,7 +182,7 @@ class FolderTaskCollector(BaseTaskCollector):
         """
         Import all task processors available for a given lang & country
         """
-        self._log(". gather-tasks lang=%s", lang)
+        self._log(".. gather-tasks lang=%s", lang)
         self._log(".. %s import from: %s/%s", self.__class__.__name__,
                   lang, country or "<all>")
         if lang is None or not isinstance(lang, str):

--- a/src/pii_extract/gather/collection/sources/json.py
+++ b/src/pii_extract/gather/collection/sources/json.py
@@ -37,7 +37,7 @@ class JsonTaskCollector(BaseTaskCollector):
             raise ConfigException("invalid format field '{}' in task spec", fmt)
 
         header = task_spec.get("header", {})
-        reformat = RawTaskDefaults(header, normalize=True)
+        reformat = RawTaskDefaults(header, normalize=True, languages=self._lang)
         rawlist = task_spec.get("tasklist", [])
         try:
             yield from reformat(rawlist)

--- a/src/pii_extract/gather/collection/sources/plugin.py
+++ b/src/pii_extract/gather/collection/sources/plugin.py
@@ -31,14 +31,15 @@ from .defs import PII_EXTRACT_PLUGIN_ID
 
 class PluginTaskCollector(BaseTaskCollector):
 
-    def __init__(self, config: Dict = None, debug: bool = False):
+    def __init__(self, config: Dict = None, debug: bool = False,
+                 languages: Iterable[str] = None):
         """
         Check available plugins and create an instance
          :param config: a dictionary possibly containing:
             (a) configuration for the collector (options for plugin loaders)
             (b) configuration to pass to each loader class
         """
-        super().__init__(debug=debug)
+        super().__init__(languages=languages, debug=debug)
         self._tasks = None
         self._plugins = []
 
@@ -52,6 +53,8 @@ class PluginTaskCollector(BaseTaskCollector):
             if not cfg.get("load", True):
                 continue        # plugin is not to be activated
             options = cfg.get("options", {})
+            if self._lang:
+                options["languages"] = self._lang
 
             # Get the class for the plugin loader
             LoaderClass = entry.load()

--- a/src/pii_extract/gather/collection/utils.py
+++ b/src/pii_extract/gather/collection/utils.py
@@ -40,7 +40,7 @@ def ensure_enum_list(pii: TYPE_TASKENUM) -> List[PiiEnum]:
 def piid_ok(piid: Dict, lang: Set[str], country: Set[str],
             pii: Set[PiiEnum]) -> bool:
     """
-    Decide if a PII descriptor agrees with a language/country filter
+    Decide if a PII descriptor agrees with a type/language/country filter
     """
     if pii and not pii & taskd_field(piid, "pii"):
         return False

--- a/src/pii_extract/gather/parser/parser.py
+++ b/src/pii_extract/gather/parser/parser.py
@@ -188,7 +188,7 @@ def _build_task_name(obj_data: Dict, pii: Dict):
 
 def _demux_field(pii_list: List[Dict], field: str) -> List[Dict]:
     """
-    Demultiplex a field that can be multiple from a PII dict
+    Demultiplex a field from a PII dict that can be multiple
     """
     out = []
     for pii in pii_list:
@@ -219,17 +219,19 @@ def parse_task_descriptor(taskd: Dict, defaults: Dict = None) -> Dict:
         raise InvPiiTask("task descriptor is not a dict")
 
     try:
+        # Get the object & info dicts
         obj_data, task_info = _parse_taskdict(taskd, defaults)
         #print("\nDATA", obj_data, task_info, taskd, sep="\n")
 
-        # Traverse the PII information and build the object fields
+        # Traverse the PII information and build the PII field
         pii_data = [_parse_piidict(t, obj_data, defaults)
                     for t in taskd.get("pii")]
 
-        # Demultiplex fields than can be multiple
+        # Demultiplex PII subfields than can be multiple
         for field in ("subtype", "lang", "country"):
             pii_data = _demux_field(pii_data, field)
 
+        # If we've got a single PII element, flatten the list
         if len(pii_data) == 1:
             pii_data = pii_data[0]
 

--- a/test/taux/auxpatch.py
+++ b/test/taux/auxpatch.py
@@ -4,7 +4,7 @@ normalized tests.
 They all use the "monkeypatch" pytest fixture
 """
 
-from typing import Dict
+from typing import Dict, Iterable
 
 from unittest.mock import Mock
 
@@ -47,11 +47,17 @@ class PluginMock:
     version = "0.999"
     description = "A plugin mock description"
 
-    def __init__(self, config: Dict = None, debug: bool = None):
-        pass
+    def __init__(self, config: Dict = None, debug: bool = None,
+                 languages: Iterable[str] = None):
+        self.languages = set(languages) if languages else None
 
     def get_plugin_tasks(self, lang: str = None):
-        return iter([RAW.TASK_PHONE_NUMBER, RAW.TASK_GOVID, RAW.TASK_CREDIT_CARD])
+        data = [RAW.TASK_PHONE_NUMBER, RAW.TASK_GOVID, RAW.TASK_CREDIT_CARD]
+        if self.languages:
+            print("\nDATA", data)
+            f = lambda d: (d.get("lang") or d["pii"][0]["lang"]) in self.languages
+            data = filter(f, data)
+        return iter(data)
 
 
 def patch_entry_points(monkeypatch):

--- a/test/unit/B_gather/sources/test_collector_folder.py
+++ b/test/unit/B_gather/sources/test_collector_folder.py
@@ -158,3 +158,20 @@ def test170_gather_all_filter():
     got = [t["pii"][0]["type"] for t in tasks]
     exp = [PiiEnum.CREDIT_CARD, PiiEnum.GOV_ID, PiiEnum.GOV_ID]
     assert exp == got
+
+
+def test180_lang_filter():
+    """
+    Check a language filter in constructor
+    """
+    tc = MyTestTaskCollector(languages=["en"])
+    got = tc.language_list()
+    assert [LANG_ANY, "en"] == got
+    tasks = tc.gather_tasks()
+    assert len(list(tasks)) == 4
+
+    tc = MyTestTaskCollector(languages=["es"])
+    got = tc.language_list()
+    assert [LANG_ANY] == got
+    tasks = tc.gather_tasks()
+    assert len(list(tasks)) == 1

--- a/test/unit/B_gather/sources/test_collector_json.py
+++ b/test/unit/B_gather/sources/test_collector_json.py
@@ -108,3 +108,18 @@ def test130_gather_all():
         }]
     }
     assert exp1 == got[1]
+
+
+def test140_gather_all_lang():
+    """
+    Apply a language filter
+    """
+    tc = mod.JsonTaskCollector(languages=["en"])
+    tc.add_tasks(_TASKFILE)
+    got = list(tc.gather_tasks())
+    assert len(got) == 2
+
+    tc = mod.JsonTaskCollector(languages=["es"])
+    tc.add_tasks(_TASKFILE)
+    got = list(tc.gather_tasks())
+    assert len(got) == 1

--- a/test/unit/B_gather/sources/test_collector_plugin.py
+++ b/test/unit/B_gather/sources/test_collector_plugin.py
@@ -89,3 +89,18 @@ def test140_gather_all_lang(fixture_entry_points):
 
     got = fetch(["es"])
     assert len(got) == 0
+
+
+def test150_init_lang(fixture_entry_points):
+    """
+    Apply a language filter
+    """
+    tc = mod.PluginTaskCollector(languages=["en"])
+
+    fetch = lambda *args: list(tc.gather_tasks(*args))
+
+    got = fetch(LANG_ANY)
+    assert len(got) == 0
+
+    got = fetch("en")
+    assert len(got) == 2

--- a/test/unit/D_api/test_A_processor.py
+++ b/test/unit/D_api/test_A_processor.py
@@ -225,11 +225,11 @@ def test210_tasks_info():
     pd.build_tasks("en")
     exp = {
         (PiiEnum.CREDIT_CARD, None): [
-            ('any', 'standard credit card',
+            ('any', 'any', 'standard credit card',
              'A simple credit card number detection for most international credit cards')
         ],
         (PiiEnum.PHONE_NUMBER, 'international phone number'): [
-            ('any', 'regex for PHONE_NUMBER:international phone number',
+            ('en', 'any', 'regex for PHONE_NUMBER:international phone number',
              'detect phone numbers that use international notation. Uses context')
         ]
     }

--- a/test/unit/E_app/test_A_info.py
+++ b/test/unit/E_app/test_A_info.py
@@ -4,9 +4,6 @@ Test the process_file function
 
 import tempfile
 from pathlib import Path
-import argparse
-
-import pytest
 
 
 import pii_extract.app.task_info as mod
@@ -18,11 +15,13 @@ CONFIGFILE = Path(__file__).parents[2] / "data" / "tasklist-example.json"
 INFO = """. Built tasks [language=en]
 
  CREDIT_CARD   
+   Language: any
    Country: any
    Name: standard credit card
      A simple credit card number detection for most international credit cards
 
  PHONE_NUMBER   international phone number
+   Language: en
    Country: any
    Name: regex for PHONE_NUMBER:international phone number
      detect phone numbers that use international notation. Uses context


### PR DESCRIPTION
 * Added `languages` argument to PiiProcessor, to restrict the pre-collection of tasks
 * Ensure a task is not built twice in the same PiiTaskCollection, if it's for the same language
 * fixed task_info api call & script